### PR TITLE
Refactor ENDSOL constant to avoid circular import

### DIFF
--- a/src/ECLlib/__init__.py
+++ b/src/ECLlib/__init__.py
@@ -26,10 +26,9 @@ from .output import (
     text_file,
 )
 from .input.intersect import AFI_file, IXF_file, IX_input
-from .unformatted_base import unfmt_block, unfmt_file
+from .unformatted_base import ENDSOL, unfmt_block, unfmt_file
 from .output.file_checker import File_checker
 from .input.gsgfile import change_resolution, read_GSG, write_GSG
-from .constants import ENDSOL
 
 __all__ = [
     "__version__",

--- a/src/ECLlib/constants.py
+++ b/src/ECLlib/constants.py
@@ -1,8 +1,32 @@
-from .unformatted_base import unfmt_block
+"""Global constants used across :mod:`ECLlib`.
+
+The module intentionally avoids importing :mod:`.unformatted_base` at import
+time to prevent a circular dependency between the two modules.  The ``ENDSOL``
+marker is therefore provided lazily via ``__getattr__``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 DEBUG = False
 ENDIAN = '>'  # Big-endian
 ECL2IX_LOG = 'ecl2ix.log'
 
-# Empty block that terminates a SEQNUM - ENDSOL section in UNRST-files
-ENDSOL = unfmt_block.from_data('ENDSOL', [], 'mess')
+__all__ = ["DEBUG", "ENDIAN", "ECL2IX_LOG", "ENDSOL"]
+
+if TYPE_CHECKING:  # pragma: no cover - import only needed for type checking
+    from .unformatted_base import unfmt_block as _unfmt_block
+
+    ENDSOL: _unfmt_block
+
+
+def __getattr__(name: str) -> Any:
+    """Provide lazy access to ``ENDSOL`` without creating import cycles."""
+
+    if name == "ENDSOL":
+        from .unformatted_base import ENDSOL as endsol
+
+        globals()[name] = endsol
+        return endsol
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/ECLlib/unformatted_base.py
+++ b/src/ECLlib/unformatted_base.py
@@ -21,7 +21,7 @@ from .constants import DEBUG, ENDIAN
 from .utils import (batched, batched_when, ensure_bytestring, expand_pattern, flatten, flatten_all, 
     index_limits, match_in_wildlist, nth, pad, pairwise, slice_range, string_split, take)
 
-__all__ = ["unfmt_header", "unfmt_block", "unfmt_file"]
+__all__ = ["unfmt_header", "unfmt_block", "unfmt_file", "ENDSOL"]
 
 class unfmt_header:                                                    # unfmt_header
 #==================================================================================================
@@ -1153,6 +1153,10 @@ class unfmt_file(File):                                                  # unfmt
             None if d is None else asarray(d, dtype=dtype).reshape(self.dim(), order='F')
             for d in data
         ]
+
+
+# Empty block that terminates a SEQNUM - ENDSOL section in UNRST-files
+ENDSOL = unfmt_block.from_data('ENDSOL', [], 'mess')
 
 
 #==================================================================================================


### PR DESCRIPTION
## Summary
- move the ENDSOL block definition into `unformatted_base` so the module can provide it directly
- lazily expose ENDSOL from `constants` to preserve the public API without reintroducing the import cycle
- update the public package initializer to import ENDSOL from `unformatted_base`

## Testing
- python -m compileall src/ECLlib

------
https://chatgpt.com/codex/tasks/task_e_68cc0b23c5508324b2c9b760db6e6a7d