### PR TITLE
fix: stream unformatted sections in one pass

### DIFF
--- a/src/ECLlib/core/iterators.py
+++ b/src/ECLlib/core/iterators.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 import inspect
 
 
-#==================================================================================================
-class AutoRefreshIterator:
-#==================================================================================================
+#===================================================================================================
+class AutoRefreshIterator:                                                     # AutoRefreshIterator
+#===================================================================================================
     """Iterator wrapper that refreshes itself when exhausted."""
 
-    #----------------------------------------------------------------------------------------------
-    def __init__(self, iterable_factory, *args, **kwargs):
-    #----------------------------------------------------------------------------------------------
+    #-----------------------------------------------------------------------------------------------
+    def __init__(self, iterable_factory, *args, **kwargs):                     # AutoRefreshIterator
+    #-----------------------------------------------------------------------------------------------
         """Initialize the RefreshIterator.
 
         Args:
@@ -29,26 +29,59 @@ class AutoRefreshIterator:
         self._iter = self._factory(*args, **kwargs)
         self._args = args
         self._kwargs = dict(kwargs)
+        self._closed = False
 
-    #----------------------------------------------------------------------------------------------
-    def __iter__(self):
-    #----------------------------------------------------------------------------------------------
+    #-----------------------------------------------------------------------------------------------
+    def __iter__(self):                                                        # AutoRefreshIterator
+    #-----------------------------------------------------------------------------------------------
         """Return an iterator over the object."""
         return self
 
-    #----------------------------------------------------------------------------------------------
-    def _refresh(self):
-    #----------------------------------------------------------------------------------------------
+    #-----------------------------------------------------------------------------------------------
+    def _refresh(self):                                                        # AutoRefreshIterator
+    #-----------------------------------------------------------------------------------------------
         """Create a fresh underlying iterator from the factory."""
-
+        if self._closed:
+            return
         self._iter = self._factory(*self._args, **self._kwargs)
 
-    #----------------------------------------------------------------------------------------------
-    def __next__(self):
-    #----------------------------------------------------------------------------------------------
+    #-----------------------------------------------------------------------------------------------
+    def _close_current(self):                                                  # AutoRefreshIterator
+    #-----------------------------------------------------------------------------------------------
+        """Close and release the current underlying iterator exactly once."""
+        current = self._iter
+        self._iter = None
+        close = getattr(current, "close", None)
+        if close is not None:
+            close()
+
+    #-----------------------------------------------------------------------------------------------
+    def close(self):                                                           # AutoRefreshIterator
+    #-----------------------------------------------------------------------------------------------
+        """Close the current iterator and prevent subsequent refreshes."""
+        if self._closed:
+            return
+        self._closed = True
+        self._close_current()
+
+    #-----------------------------------------------------------------------------------------------
+    def __next__(self):                                                        # AutoRefreshIterator
+    #-----------------------------------------------------------------------------------------------
         """Return the next item from the iterator."""
+        if self._closed:
+            raise StopIteration
+        refreshed = self._iter is None
+        if refreshed:
+            self._refresh()
         try:
             return next(self._iter)
         except StopIteration:
+            self._close_current()
+            if self._closed or refreshed:
+                raise
             self._refresh()
-            return next(self._iter)
+            try:
+                return next(self._iter)
+            except StopIteration:
+                self._close_current()
+                raise

--- a/src/ECLlib/core/unformatted.py
+++ b/src/ECLlib/core/unformatted.py
@@ -12,7 +12,7 @@ from .datatypes import DTYPE
 from .file import File
 from ..config import DEBUG, ENDIAN
 from ..utils import (batched, batched_when, ensure_bytestring, expand_pattern, flatten, flatten_all,
-    index_limits, match_in_wildlist, nth, pad, pairwise, slice_range, string_split, take)
+    index_limits, match_in_wildlist, nth, pad, slice_range, string_split, take)
 
 __all__ = ["unfmt_header", "unfmt_block", "unfmt_section_span", "unfmt_file", "ENDSOL"]
 
@@ -960,43 +960,76 @@ class unfmt_file(File):                                                         
                 yield unfmt_block(header=header, file_obj=file, file=self.path)
 
 
-    #----------------------------------------------------------------------------------------------
-    def tail_blocks(self, **kwargs):                                                   # unfmt_file
-    #----------------------------------------------------------------------------------------------
-        """Return the last blocks in the file."""
+    #-----------------------------------------------------------------------------------------------
+    def tail_blocks(self, start=None, use_mmap=True, **kwargs):                         # unfmt_file
+    #-----------------------------------------------------------------------------------------------
+        """Return blocks in reverse file order from a mmap or seekable file."""
         if not self.is_file() or self.size() < 24: # Header is 24 bytes
-            return ()
+            return iter(())
+        endpos = self.size() if start is None else min(start, self.size())
+        if use_mmap:
+            return self.tail_blocks_from_mmap(endpos)
+        return self.tail_blocks_from_file(endpos)
+
+    #-----------------------------------------------------------------------------------------------
+    def _tail_blocks_from_source(self, source, endpos, mapped):                         # unfmt_file
+    #-----------------------------------------------------------------------------------------------
+        """Yield reverse blocks from an open mmap or seekable binary file."""
+        pos = endpos
+        while pos > 0:
+            block_end = pos
+            header = None
+            while pos >= 8:
+                try:
+                    source.seek(pos - 4)
+                    raw_size = source.read(4)
+                    if len(raw_size) != 4:
+                        return
+                    size = unpack(ENDIAN+'i', raw_size)[0]
+                    record_start = pos - size - 8
+                    if size < 0 or record_start < 0:
+                        return
+                    if size == 16:
+                        source.seek(record_start + 4)
+                        raw_header = source.read(16)
+                        if len(raw_header) == 16 and raw_header[12:16] in DTYPE:
+                            header = self.read_header(raw_header, record_start)
+                            if header:
+                                # A valid header is not a complete block until every declared payload
+                                # record reaches the current physical block boundary.
+                                if header.endpos != block_end:
+                                    return
+                                break
+                    pos = record_start
+                except (OSError, ValueError, struct_error):
+                    return
+            if header is None:
+                return
+
+            # Payload methods borrow this open source until iteration advances or closes.
+            if mapped:
+                yield unfmt_block(header=header, data=source, file=self.path)
+            else:
+                yield unfmt_block(header=header, file_obj=source, file=self.path)
+            pos = header.startpos
+
+    #-----------------------------------------------------------------------------------------------
+    def tail_blocks_from_mmap(self, endpos):                                            # unfmt_file
+    #-----------------------------------------------------------------------------------------------
+        """Yield reverse blocks backed by a memory map."""
+        try:
+            with open(self.path, mode='rb') as file:
+                with mmap(file.fileno(), length=0, access=ACCESS_READ) as data:
+                    yield from self._tail_blocks_from_source(data, endpos, mapped=True)
+        except ValueError: # Catch 'cannot mmap an empty file'
+            return
+
+    #-----------------------------------------------------------------------------------------------
+    def tail_blocks_from_file(self, endpos):                                            # unfmt_file
+    #-----------------------------------------------------------------------------------------------
+        """Yield reverse blocks using seek-based reads without creating an mmap."""
         with open(self.path, mode='rb') as file:
-            with mmap(file.fileno(), length=0, access=ACCESS_READ) as data:
-                # Goto end of file
-                data.seek(0, 2)
-                while data.tell() > 0:
-                    end = data.tell()
-                    # Header
-                    # Rewind until we find a header
-                    while data.tell() > 0:
-                        try:
-                            data.seek(-4, 1)
-                            size = unpack(ENDIAN+'i',data.read(4))[0]
-                            data.seek(-4-size, 1)
-                            # if self.is_header(data, size, data.tell()):
-                            pos = data.tell()
-                            ### Check if this is a header
-                            if size == 16 and data[pos+12:pos+16] in DTYPE:
-                                start = data.tell()-4
-                                key, length, typ = unpack(ENDIAN+'8si4s', data.read(16))
-                                data.seek(4, 1)
-                                # Found header
-                                break 
-                            data.seek(-4, 1)
-                        except (ValueError, struct_error):
-                            return #()
-                    ### Value array
-                    #data_start = data.tell()
-                    data.seek(start, 0)
-                    yield unfmt_block(header=unfmt_header(key, length, typ, start, end), data=data, file=self.path)
-                    # yield unfmt_block(key=key, length=length, type=typ, start=start, end=end,
-                    #                 data=data, file=self.path)
+            yield from self._tail_blocks_from_source(file, endpos, mapped=False)
 
     #----------------------------------------------------------------------------------------------
     def fix_errors(self):                                                              # unfmt_file
@@ -1137,9 +1170,9 @@ class unfmt_file(File):                                                         
         yield n
 
 
-    #----------------------------------------------------------------------------------------------
-    def section_blocks(self, tail=False, only_new=False, **kwargs):                    # unfmt_file
-    #----------------------------------------------------------------------------------------------
+    #-----------------------------------------------------------------------------------------------
+    def section_blocks(self, tail=False, only_new=False, **kwargs):                     # unfmt_file
+    #-----------------------------------------------------------------------------------------------
         """
         Yields batches of blocks corresponding to sections in the file. The sections are 
         determined by the start blocks defined in the file.
@@ -1157,24 +1190,70 @@ class unfmt_file(File):                                                         
         """
         self.exists(raise_error=True)
         blocks_func = self.tail_blocks if tail else self.blocks
-        start_indx = self.section_start_indices(tail=tail, start=self._endpos if only_new else None)
-        # Use pairwise to get start and end positions of each section
-        # TODO: use start argument to skip to correct section
-        section_pos = islice(pairwise(start_indx), None)
-        blocks_iter = blocks_func(only_new=only_new, **kwargs)
-        prev = 0
-        a, b = next(section_pos, (0, 0))
-        while True:
-            # Use islice to get blocks from a to b, where a and b are the start and end
-            # Need to subtract prev to get the correct slice since the iterator is consumed
-            batch = tuple(islice(blocks_iter, a - prev, b - prev))
-            if not batch:
-                break
-            yield batch
-            prev = b
-            a, b = next(section_pos, (b, b))
-            if a == b:  # No more sections
-                break
+        marker = self.end if tail else self.start
+        source_kwargs = dict(kwargs)
+        transactional = only_new and not tail
+        commit_complete = transactional and bool(self.end)
+        if transactional:
+            # Cursor updates occur only at section boundaries so early close cannot skip data.
+            source_kwargs["start"] = self._endpos
+            blocks_iter = iter(blocks_func(only_new=False, **source_kwargs))
+        else:
+            blocks_iter = iter(blocks_func(only_new=only_new, **source_kwargs))
+
+        batch = []
+        source_end = self.size()
+        last_complete_end = self._endpos
+        try:
+            for block in blocks_iter:
+                if block.endpos > source_end:
+                    # A parseable header does not make its declared payload physically complete.
+                    break
+                last_complete_end = block.endpos
+                if marker in block:
+                    if batch:
+                        if commit_complete:
+                            # A second start before the declared end leaves the first section partial.
+                            return
+                        if transactional:
+                            self._endpos = block.startpos
+                        yield tuple(batch)
+                    batch = [block]
+                elif batch:
+                    batch.append(block)
+
+                if (commit_complete and batch and self.end in block
+                        and block.endpos <= source_end):
+                    self._endpos = block.endpos
+                    yield tuple(batch)
+                    batch = []
+                    continue
+
+                # Avoid exhausting the borrowed source before yielding the final static section.
+                source_boundary = block.startpos == 0 if tail else block.endpos >= source_end
+                if not commit_complete and source_boundary and batch:
+                    if transactional:
+                        self._endpos = last_complete_end
+                    yield tuple(batch)
+                    batch = []
+                    return
+
+            if batch and not commit_complete:
+                if transactional:
+                    self._endpos = last_complete_end
+                    yield tuple(batch)
+                    return
+                # Invalid trailing bytes may exhaust the original source before its final tuple is
+                # yielded. Reborrow a seekable source so that static grouping semantics are retained.
+                with open(self.path, mode='rb') as file:
+                    for block in batch:
+                        block._data = None
+                        block._file_obj = file
+                    yield tuple(batch)
+        finally:
+            close = getattr(blocks_iter, "close", None)
+            if close is not None:
+                close()
     
 
     #-----------------------------------------------------------------------------------------------

--- a/tests/test_unformatted_sections.py
+++ b/tests/test_unformatted_sections.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ECLlib import AutoRefreshIterator, unfmt_block, unfmt_file
+from ECLlib.core import unformatted as unformatted_module
+
+
+#---------------------------------------------------------------------------------------------------
+def _serialized_block(key, value=None):
+#---------------------------------------------------------------------------------------------------
+    """Return one integer or message block serialized for a test file."""
+    if value is None:
+        return unfmt_block.from_data(key, [], "mess").as_bytes()
+    return unfmt_block.from_data(key, [value], "int").as_bytes()
+
+
+#---------------------------------------------------------------------------------------------------
+def _write_section_file(path, sections, *, partial=()):
+#---------------------------------------------------------------------------------------------------
+    """Write complete start/end-delimited sections and an optional partial section."""
+    with open(path, "wb") as file:
+        for step, key, value in sections:
+            file.write(_serialized_block("SEQNUM", step))
+            file.write(_serialized_block(key, value))
+            file.write(_serialized_block("ENDSOL"))
+        for key, value in partial:
+            file.write(_serialized_block(key, value))
+
+
+#---------------------------------------------------------------------------------------------------
+def _section_reader(path):
+#---------------------------------------------------------------------------------------------------
+    """Return a generic unformatted reader configured with restart section markers."""
+    reader = unfmt_file(path)
+    reader.start = "SEQNUM"
+    reader.end = "ENDSOL"
+    return reader
+
+
+#---------------------------------------------------------------------------------------------------
+def _section_keys(reader, **kwargs):
+#---------------------------------------------------------------------------------------------------
+    """Materialize section keys while their borrowed backing source remains open."""
+    return [[block.key() for block in section] for section in reader.section_blocks(**kwargs)]
+
+
+#---------------------------------------------------------------------------------------------------
+def test_section_blocks_preserves_forward_and_tail_order(tmp_path):
+#---------------------------------------------------------------------------------------------------
+    """Preserve section order and reverse each tuple when reading from the tail."""
+    path = tmp_path / "ordered.UNRST"
+    _write_section_file(path, [(1, "PRESSURE", 10), (2, "SWAT", 20)])
+    reader = _section_reader(path)
+
+    assert _section_keys(reader) == [
+        ["SEQNUM", "PRESSURE", "ENDSOL"],
+        ["SEQNUM", "SWAT", "ENDSOL"],
+    ]
+    assert _section_keys(reader, tail=True) == [
+        ["ENDSOL", "SWAT", "SEQNUM"],
+        ["ENDSOL", "PRESSURE", "SEQNUM"],
+    ]
+    assert list(reader.section_start_indices()) == [0, 3, 6]
+    assert list(reader.section_start_indices(tail=True)) == [0, 3, 6]
+
+
+#---------------------------------------------------------------------------------------------------
+def test_section_blocks_reads_source_and_headers_once(tmp_path, monkeypatch):
+#---------------------------------------------------------------------------------------------------
+    """Group sections using one source iterator and one visit per block header."""
+    path = tmp_path / "single-pass.UNRST"
+    _write_section_file(path, [(1, "PRESSURE", 10), (2, "SWAT", 20)])
+    reader = _section_reader(path)
+    source_calls = 0
+    header_calls = 0
+    original_blocks = reader.blocks
+    original_read_header = reader.read_header
+
+    def counted_blocks(**kwargs):
+        """Count construction of the underlying forward block source."""
+        nonlocal source_calls
+        source_calls += 1
+        yield from original_blocks(**kwargs)
+
+    def counted_read_header(data, startpos):
+        """Count each parsed unformatted block header."""
+        nonlocal header_calls
+        header_calls += 1
+        return original_read_header(data, startpos)
+
+    monkeypatch.setattr(reader, "blocks", counted_blocks)
+    monkeypatch.setattr(reader, "read_header", counted_read_header)
+
+    assert len(_section_keys(reader)) == 2
+    assert source_calls == 1
+    assert header_calls == 6
+
+
+#---------------------------------------------------------------------------------------------------
+def test_use_mmap_false_avoids_mmap_for_forward_and_tail(tmp_path, monkeypatch):
+#---------------------------------------------------------------------------------------------------
+    """Use seek-based sources in both directions when memory mapping is disabled."""
+    path = tmp_path / "without-mmap.UNRST"
+    _write_section_file(path, [(1, "PRESSURE", 10), (2, "SWAT", 20)])
+    reader = _section_reader(path)
+
+    def fail_mmap(*args, **kwargs):
+        """Fail if a disabled mmap path attempts to construct a mapping."""
+        raise AssertionError("mmap must not be used")
+
+    monkeypatch.setattr(unformatted_module, "mmap", fail_mmap)
+
+    assert len(_section_keys(reader, use_mmap=False)) == 2
+    assert len(_section_keys(reader, tail=True, use_mmap=False)) == 2
+
+
+#---------------------------------------------------------------------------------------------------
+@pytest.mark.parametrize("use_mmap", [True, False])
+def test_tail_blocks_empty_sources_and_zero_start_are_iterators(tmp_path, use_mmap):
+#---------------------------------------------------------------------------------------------------
+    """Return exhausted iterators for unavailable data and an explicit zero boundary."""
+    missing = tmp_path / "missing.UNRST"
+    empty = tmp_path / "empty.UNRST"
+    short = tmp_path / "short.UNRST"
+    valid = tmp_path / "valid.UNRST"
+    empty.touch()
+    short.write_bytes(b"short")
+    _write_section_file(valid, [(1, "PRESSURE", 10)])
+
+    for path in (missing, empty, short):
+        assert next(_section_reader(path).tail_blocks(use_mmap=use_mmap), None) is None
+    assert next(_section_reader(valid).tail_blocks(start=0, use_mmap=use_mmap), None) is None
+
+
+#---------------------------------------------------------------------------------------------------
+@pytest.mark.parametrize("use_mmap", [True, False])
+def test_tail_blocks_rejects_truncated_multi_record_payload(tmp_path, use_mmap):
+#---------------------------------------------------------------------------------------------------
+    """Fail closed on a truncated tail block and accept it after all payload records arrive."""
+    path = tmp_path / "truncated-tail.UNRST"
+    values = np.arange(1505, dtype=np.int32)
+    terminal_bytes = unfmt_block.from_data("CONNXT", values, "int").as_bytes()
+    with open(path, "wb") as file:
+        file.write(_serialized_block("ENDSOL"))
+        file.write(terminal_bytes[:24])
+
+    reader = _section_reader(path)
+    assert next(reader.tail_blocks(use_mmap=use_mmap), None) is None
+
+    with open(path, "ab") as file:
+        file.write(terminal_bytes[24:])
+
+    blocks = reader.tail_blocks(use_mmap=use_mmap)
+    block = next(blocks)
+    assert block.key() == "CONNXT"
+    assert np.array_equal(block.data(), values)
+    blocks.close()
+
+
+#---------------------------------------------------------------------------------------------------
+@pytest.mark.parametrize("use_mmap", [True, False])
+def test_final_section_payload_source_lives_while_yielded(tmp_path, use_mmap):
+#---------------------------------------------------------------------------------------------------
+    """Keep the final section's borrowed payload source open until iteration resumes."""
+    path = tmp_path / "payload-lifetime.UNRST"
+    _write_section_file(path, [(1, "PRESSURE", 123)])
+    sections = _section_reader(path).section_blocks(use_mmap=use_mmap)
+
+    section = next(sections)
+    payload = section[1]
+    source = payload._data if use_mmap else payload._file_obj
+    assert source.closed is False
+    assert payload.data().tolist() == [123]
+
+    sections.close()
+    assert source.closed is True
+
+
+#---------------------------------------------------------------------------------------------------
+@pytest.mark.parametrize("use_mmap", [True, False])
+def test_section_blocks_early_close_closes_borrowed_source(tmp_path, use_mmap):
+#---------------------------------------------------------------------------------------------------
+    """Close the block source deterministically when a section consumer stops early."""
+    path = tmp_path / "early-close.UNRST"
+    _write_section_file(path, [(1, "PRESSURE", 10), (2, "SWAT", 20)])
+    sections = _section_reader(path).section_blocks(use_mmap=use_mmap)
+
+    section = next(sections)
+    payload = section[1]
+    source = payload._data if use_mmap else payload._file_obj
+    assert source.closed is False
+
+    sections.close()
+    assert source.closed is True
+
+
+#---------------------------------------------------------------------------------------------------
+def test_static_section_blocks_still_yields_partial_final_section(tmp_path):
+#---------------------------------------------------------------------------------------------------
+    """Retain static grouping semantics for a final section without its end marker."""
+    path = tmp_path / "static-partial.UNRST"
+    _write_section_file(path, [], partial=[("SEQNUM", 1), ("PRESSURE", 10)])
+
+    assert _section_keys(_section_reader(path), use_mmap=False) == [
+        ["SEQNUM", "PRESSURE"]
+    ]
+
+
+#---------------------------------------------------------------------------------------------------
+@pytest.mark.parametrize("use_mmap", [True, False])
+def test_only_new_withholds_partial_append_and_emits_once_when_complete(tmp_path, use_mmap):
+#---------------------------------------------------------------------------------------------------
+    """Commit the only-new cursor only after an appended section receives its end marker."""
+    path = tmp_path / "appending.UNRST"
+    _write_section_file(
+        path,
+        [(1, "PRESSURE", 10)],
+        partial=[("SEQNUM", 2), ("SWAT", 20)],
+    )
+    reader = _section_reader(path)
+    complete_size = sum(
+        len(_serialized_block(key, value))
+        for key, value in (("SEQNUM", 1), ("PRESSURE", 10), ("ENDSOL", None))
+    )
+
+    assert _section_keys(reader, only_new=True, use_mmap=use_mmap) == [
+        ["SEQNUM", "PRESSURE", "ENDSOL"]
+    ]
+    assert reader._endpos == complete_size
+
+    assert _section_keys(reader, only_new=True, use_mmap=use_mmap) == []
+    assert reader._endpos == complete_size
+
+    with open(path, "ab") as file:
+        file.write(_serialized_block("ENDSOL"))
+
+    assert _section_keys(reader, only_new=True, use_mmap=use_mmap) == [
+        ["SEQNUM", "SWAT", "ENDSOL"]
+    ]
+    assert reader._endpos == path.stat().st_size
+    assert _section_keys(reader, only_new=True, use_mmap=use_mmap) == []
+
+
+#---------------------------------------------------------------------------------------------------
+@pytest.mark.parametrize("use_mmap", [True, False])
+def test_only_new_withholds_terminal_block_with_truncated_payload(tmp_path, use_mmap):
+#---------------------------------------------------------------------------------------------------
+    """Do not commit a declared terminal block until its nonempty payload is complete."""
+    path = tmp_path / "truncated-terminal.UNRST"
+    start_bytes = _serialized_block("TIME", 1)
+    terminal_bytes = _serialized_block("CONNXT", 99)
+    with open(path, "wb") as file:
+        file.write(start_bytes)
+        file.write(terminal_bytes[:24])
+
+    reader = unfmt_file(path)
+    reader.start = "TIME"
+    reader.end = "CONNXT"
+
+    assert _section_keys(reader, only_new=True, use_mmap=use_mmap) == []
+    assert reader._endpos == 0
+
+    with open(path, "ab") as file:
+        file.write(terminal_bytes[24:])
+
+    assert _section_keys(reader, only_new=True, use_mmap=use_mmap) == [
+        ["TIME", "CONNXT"]
+    ]
+    assert reader._endpos == path.stat().st_size
+    assert _section_keys(reader, only_new=True, use_mmap=use_mmap) == []
+
+
+#---------------------------------------------------------------------------------------------------
+@pytest.mark.parametrize("use_mmap", [True, False])
+def test_only_new_without_end_rereads_next_start_after_early_close(tmp_path, use_mmap):
+#---------------------------------------------------------------------------------------------------
+    """Commit at the next start marker so closing early cannot discard the following section."""
+    path = tmp_path / "no-end-early-close.UNRST"
+    with open(path, "wb") as file:
+        for key, value in (("START", 1), ("VALUE", 10), ("START", 2), ("VALUE", 20)):
+            file.write(_serialized_block(key, value))
+
+    reader = unfmt_file(path)
+    reader.start = "START"
+    sections = reader.section_blocks(only_new=True, use_mmap=use_mmap)
+    first = next(sections)
+    second_start = first[-1].endpos
+    assert [block.key() for block in first] == ["START", "VALUE"]
+    assert reader._endpos == second_start
+    sections.close()
+
+    assert _section_keys(reader, only_new=True, use_mmap=use_mmap) == [
+        ["START", "VALUE"]
+    ]
+    assert reader._endpos == path.stat().st_size
+
+
+#---------------------------------------------------------------------------------------------------
+@pytest.mark.parametrize("use_mmap", [True, False])
+def test_only_new_without_end_does_not_commit_truncated_next_start(tmp_path, use_mmap):
+#---------------------------------------------------------------------------------------------------
+    """Commit only complete blocks when the next start marker has a truncated payload."""
+    path = tmp_path / "no-end-truncated-start.UNRST"
+    second_start = _serialized_block("START", 2)
+    with open(path, "wb") as file:
+        file.write(_serialized_block("START", 1))
+        file.write(_serialized_block("VALUE", 10))
+        expected_cursor = file.tell()
+        file.write(second_start[:24])
+
+    reader = unfmt_file(path)
+    reader.start = "START"
+    assert _section_keys(reader, only_new=True, use_mmap=use_mmap) == [
+        ["START", "VALUE"]
+    ]
+    assert reader._endpos == expected_cursor
+
+    with open(path, "ab") as file:
+        file.write(second_start[24:])
+        file.write(_serialized_block("VALUE", 20))
+
+    assert _section_keys(reader, only_new=True, use_mmap=use_mmap) == [
+        ["START", "VALUE"]
+    ]
+    assert reader._endpos == path.stat().st_size
+
+
+#---------------------------------------------------------------------------------------------------
+def test_auto_refresh_iterator_closes_exhausted_sources_and_stays_closed():
+#---------------------------------------------------------------------------------------------------
+    """Close refreshed generators exactly once and never reopen after explicit close."""
+    events = []
+    factory_calls = 0
+
+    def factory(*, only_new=False):
+        """Create one populated source followed by empty refreshed sources."""
+        nonlocal factory_calls
+        index = factory_calls
+        factory_calls += 1
+        if index:
+            assert events == [f"closed-{previous}" for previous in range(index)]
+
+        def source():
+            """Yield the initial value and record deterministic generator closure."""
+            try:
+                if index == 0:
+                    yield 7
+            finally:
+                events.append(f"closed-{index}")
+
+        return source()
+
+    iterator = AutoRefreshIterator(factory)
+    assert next(iterator) == 7
+    with pytest.raises(StopIteration):
+        next(iterator)
+    assert events == ["closed-0", "closed-1"]
+    assert factory_calls == 2
+
+    with pytest.raises(StopIteration):
+        next(iterator)
+    assert events == ["closed-0", "closed-1", "closed-2"]
+    assert factory_calls == 3
+
+    iterator.close()
+    iterator.close()
+    iterator._refresh()
+    with pytest.raises(StopIteration):
+        next(iterator)
+    assert events == ["closed-0", "closed-1", "closed-2"]
+    assert factory_calls == 3


### PR DESCRIPTION
## Summary

- replace the section-boundary pre-scan and second pass with a one-pass section iterator
- provide seek-based reverse iteration when `use_mmap=False`
- make growing-file cursor updates transactional so partial sections and early consumer closure cannot lose data
- add deterministic, idempotent `AutoRefreshIterator.close()`
- fail closed on physically truncated tail blocks while preserving public indexing utilities

## Verification

- ECLlib focused streaming tests: 21 passed
- affected UNRST/CLI tests: 54 passed
- full ECLlib suite: 162 passed, 6 skipped
- independent candidate review approved after mmap/file cursor, truncation, reverse-order, and lifetime checks
- pyFlow extended drift: exact zero for Eclipse RFT, INTERSECT-v5 RFT and UNSMRY, and 11-field Model_From_IXF geochemistry
- pyFlow live drift: exact zero for OPM and INTERSECT
- INTERSECT v5 archive verified at 1,279,184,980 bytes, SHA-256 `99f3ffebb7c04ca862652c6c2c43afda2e48fa475ce08b7eeb8dc9af4d3c8189`

## Dependency

A dependent pyFlow draft PR will pin commit `f25f8a359fc699c7ff4827e356fc4627240c6f98`.

This PR is intentionally draft and must not be merged automatically.